### PR TITLE
add Iso[JsonObject, Map[String, Json]]

### DIFF
--- a/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
+++ b/optics/src/main/scala/io/circe/optics/JsonObjectOptics.scala
@@ -3,7 +3,7 @@ package io.circe.optics
 import cats.{ Applicative, Foldable, Monoid, Traverse }
 import cats.instances.ListInstances
 import io.circe.{ Json, JsonObject }
-import monocle.{ Fold, Lens, Traversal }
+import monocle.{ Fold, Iso, Lens, Traversal }
 import monocle.function.{ At, Each, FilterIndex, Index }
 
 /**
@@ -33,6 +33,9 @@ trait JsonObjectOptics extends ListInstances {
           obj => optVal.fold(obj.remove(field))(value => obj.add(field, value))
         )
     }
+
+  final lazy val jsonObjectIso: Iso[JsonObject, Map[String, Json]] =
+    Iso((_: JsonObject).toMap)(JsonObject.fromMap)
 
   implicit final lazy val jsonObjectFilterIndex: FilterIndex[JsonObject, String, Json] =
     new FilterIndex[JsonObject, String, Json] {

--- a/optics/src/test/scala/io/circe/optics/LawsTests.scala
+++ b/optics/src/test/scala/io/circe/optics/LawsTests.scala
@@ -3,9 +3,9 @@ package io.circe.optics
 import cats.Eq
 import cats.instances.list._
 import cats.instances.option._
-import monocle.{ Lens, Optional, Prism, Traversal }
+import monocle.{ Iso, Lens, Optional, Prism, Traversal }
 import monocle.function.{ At, Each, FilterIndex, Index }
-import monocle.law.{ LensLaws, OptionalLaws, PrismLaws, TraversalLaws }
+import monocle.law.{ IsoLaws, LensLaws, OptionalLaws, PrismLaws, TraversalLaws }
 import monocle.law.discipline.isEqToProp
 import org.scalacheck.{ Arbitrary, Prop, Shrink }
 import org.typelevel.discipline.Laws
@@ -96,6 +96,24 @@ object LawsTests extends Laws {
       "consistent set with modify" -> Prop.forAll((s: S, a: A) => laws.consistentSetModify(s, a)),
       "consistent modify with modifyId" -> Prop.forAll((s: S, g: A => A) => laws.consistentModifyModifyId(s, g)),
       "consistent getOption with modifyId" -> Prop.forAll((s: S) => laws.consistentGetOptionModifyId(s))
+    )
+  }
+
+  def isoTests[S: Arbitrary: Shrink: Eq, A: Arbitrary: Shrink: Eq](iso: Iso[S, A])(
+    implicit
+    arbAA: Arbitrary[A => A]
+  ): RuleSet = {
+    val laws: IsoLaws[S, A] = new IsoLaws(iso)
+
+    new SimpleRuleSet(
+      "Iso",
+      "round trip one way" -> Prop.forAll((s: S) => laws.roundTripOneWay(s)),
+      "round trip other way" -> Prop.forAll((a: A) => laws.roundTripOtherWay(a)),
+      "modify id = id" -> Prop.forAll((s: S) => laws.modifyIdentity(s)),
+      "compose modify" -> Prop.forAll((s: S, f: A => A, g: A => A) => laws.composeModify(s, f, g)),
+      "consistent set with modify" -> Prop.forAll((s: S, a: A) => laws.consistentSetModify(s, a)),
+      "consistent modify with modifyId" -> Prop.forAll((s: S, g: A => A) => laws.consistentModifyModifyId(s, g)),
+      "consistent getOption with modifyId" -> Prop.forAll((s: S) => laws.consistentGetModifyId(s))
     )
   }
 

--- a/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
+++ b/optics/src/test/scala/io/circe/optics/OpticsSuite.scala
@@ -41,6 +41,7 @@ class OpticsSuite extends CirceSuite {
 
   checkAll("plated Json", LawsTests.traversalTests(plate[Json]))
 
+  checkAll("jsonObjectIso", LawsTests.isoTests(jsonObjectIso))
   checkAll("jsonObjectEach", LawsTests.eachTests[JsonObject, Json])
   checkAll("jsonObjectAt", LawsTests.atTests[JsonObject, String, Option[Json]])
   checkAll("jsonObjectIndex", LawsTests.indexTests[JsonObject, String, Json])


### PR DESCRIPTION
This is basically a resurrection of https://github.com/circe/circe/pull/612. I tried to add a unsafe instance of `Traversal[Map[K, V], (K, V)]` in https://github.com/optics-dev/Monocle/pull/867. I think the use case is still relevant. I recently want to rename json keys from "_key" to "key". I find no easy way to do this.