### PR TITLE
Update monocle-core, monocle-law organisation to 'optics-dev'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ limitations under the License.
 [api-docs]: https://circe.github.io/circe-optics/api/io/circe/
 [circe]: https://github.com/circe/circe
 [code-of-conduct]: https://www.scala-lang.org/conduct.html
-[contributing]: https://circe.github.io/circe/contributing.html
-[monocle]: https://github.com/julien-truffaut/Monocle
+[contributing]: https://github.com/circe/circe/blob/master/CONTRIBUTING.md
+[monocle]: https://github.com/optics-dev/Monocle

--- a/build.sbt
+++ b/build.sbt
@@ -68,8 +68,8 @@ lazy val optics = crossProject(JSPlatform, JVMPlatform)
     moduleName := "circe-optics",
     mimaPreviousArtifacts := Set("io.circe" %% "circe-optics" % previousCirceOpticsVersion),
     libraryDependencies ++= Seq(
-      "com.github.julien-truffaut" %%% "monocle-core" % monocleVersion,
-      "com.github.julien-truffaut" %%% "monocle-law" % monocleVersion % Test,
+      "optics-dev" %%% "monocle-core" % monocleVersion,
+      "optics-dev" %%% "monocle-law" % monocleVersion % Test,
       "io.circe" %%% "circe-core" % circeVersion,
       "io.circe" %%% "circe-generic" % circeVersion % Test,
       "io.circe" %%% "circe-testing" % circeVersion % Test,


### PR DESCRIPTION
## What
- Updates the monocle organisation
  - Scala Steward should then bump the version
- Update documentation links

## Why
- Scala-Steward isn't picking up the latest version of optics since the organisation changed.
- Contribution link is dead